### PR TITLE
feat: Swap SSH and sshpiper ports

### DIFF
--- a/roles/sshpiper/tasks/main.yml
+++ b/roles/sshpiper/tasks/main.yml
@@ -1,70 +1,140 @@
 ---
+- name: Download and install Go
+  block:
+    - name: Download Go
+      get_url:
+        url: "{{ go_download_url }}" 
+        dest: "{{ go_download_path }}"
 
-- name: Download Go
-  get_url:
-    url: "{{ go_download_url }}" 
-    dest: "{{ go_download_path }}"
+    - name: Extract Go
+      ansible.builtin.unarchive:
+        src: "{{ go_download_path }}" 
+        dest: "{{ go_binary_path }}"
+        remote_src: yes
 
-- name: Extract Go
-  ansible.builtin.unarchive:
-    src: "{{ go_download_path }}" 
-    dest: "{{ go_binary_path }}"
-    remote_src: yes
+    - name: Set Go path
+      ansible.builtin.lineinfile:
+        path: /etc/profile
+        line: "export PATH=$PATH:{{ go_binary_path }}/go/bin"
+        state: present
 
-- name: Set Go path
-  ansible.builtin.lineinfile:
-    path: /etc/profile
-    line: "export PATH=$PATH:{{ go_binary_path }}/go/bin"
-    state: present
+- name: Install and configure sshpiper
+  block:
+    - name: Clone sshpiper repository
+      ansible.builtin.git:
+        repo: "{{ sshpiper_git_repo }}"
+        version: "{{ sshpiper_version }}"
+        dest: "{{ sshpiper_dest_dir }}"
+        update: true
+        recursive: true
 
-- name: Clone sshpiper repository
-  ansible.builtin.git:
-    repo: "{{ sshpiper_git_repo }}"
-    version: "{{ sshpiper_version }}"
-    dest: "{{ sshpiper_dest_dir }}"
-    update: true
-    recursive: true
+    - name: Create output directory for sshpiper
+      ansible.builtin.file:
+        path: "{{sshpiper_bin_dir}}"
+        state: directory
 
-- name: Create output directory for sshpiper
-  ansible.builtin.file:
-    path: "{{sshpiper_bin_dir}}"
-    state: directory
+    - name: Build sshpiper
+      ansible.builtin.command: go build -tags full -o out ./...
+      args:
+        chdir: "{{sshpiper_dest_dir}}"
+      environment:
+        PATH: "{{ ansible_env.PATH }}:{{go_binary_path}}/go/bin"
 
-- name: Build sshpiper
-  ansible.builtin.command: go build -tags full -o out ./...
-  args:
-    chdir: "{{sshpiper_dest_dir}}"
-  environment:
-    PATH: "{{ ansible_env.PATH }}:{{go_binary_path}}/go/bin"
+    - name: Configure sshpiper yaml plugin
+      ansible.builtin.template:
+        src: sshpiperd.yaml.j2
+        dest: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
+        mode: '0600'
+        backup: true
 
-- name: Configure sshpiper yaml plugin
-  ansible.builtin.template:
-    src: sshpiperd.yaml.j2
-    dest: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
-    backup: true
+- name: Modify SSH and sshpiper configurations
+  block:
+    - name: Change SSH port to 2222
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^#?Port '
+        line: 'Port 2222'
+      notify: Restart SSH
 
-- name: Allow port 2222 traffic for sshpiper in Shorewall
-  ansible.builtin.blockinfile:
-    path: /etc/shorewall/rules
-    insertbefore: "^#LAST LINE"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK"
-    backup: true
-    block: |
-      # -- Allow port 2222 traffic for sshpiper from internet to master
-      ACCEPT:info   net            fw              tcp     2222
+    - name: Update sshpiper configuration to use port 22
+      ansible.builtin.lineinfile:
+        path: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
+        regexp: '^(\s*)listen_addr:'
+        line: '\1listen_addr: 0.0.0.0:22'
+      notify: Restart sshpiper
 
-- name: Restart Shorewall service
-  ansible.builtin.systemd:
-    name: shorewall
-    state: restarted
+    - name: Update Shorewall rules for SSH and sshpiper
+      ansible.builtin.blockinfile:
+        path: /etc/shorewall/rules
+        insertbefore: "^#LAST LINE"
+        marker: "# {mark} ANSIBLE MANAGED BLOCK"
+        backup: true
+        block: |
+          # -- Allow port 22 traffic for sshpiper from internet to master
+          ACCEPT:info   net            fw              tcp     22
+          # -- Allow port 2222 traffic for SSH from internet to master
+          ACCEPT:info   net            fw              tcp     2222
+      notify: Restart Shorewall
 
-- name: Install systemd service file for sshpiper
-  ansible.builtin.template:
-    src: sshpiperd.service.j2
-    dest: /etc/systemd/system/sshpiperd.service
-    backup: true
-  
-- name: Enable sshpiperd service
-  ansible.builtin.service:
-    name: sshpiperd
-    enabled: yes
+- name: Setup services
+  block:
+    - name: Install systemd service file for sshpiper
+      ansible.builtin.template:
+        src: sshpiperd.service.j2
+        dest: /etc/systemd/system/sshpiperd.service
+        backup: true
+      notify: Reload systemd
+
+    - name: Enable and start sshpiper service
+      ansible.builtin.systemd:
+        name: sshpiperd
+        enabled: yes
+        state: started
+
+    - name: Ensure SSH service is enabled and started
+      ansible.builtin.systemd:
+        name: sshd
+        enabled: yes
+        state: started
+
+- name: Verify configurations
+  block:
+    - name: Check if sshpiper is listening on port 22
+      ansible.builtin.wait_for:
+        port: 22
+        timeout: 5
+      register: sshpiper_check
+      ignore_errors: yes
+
+    - name: Check if SSH is listening on port 2222
+      ansible.builtin.wait_for:
+        port: 2222
+        timeout: 5
+      register: ssh_check
+      ignore_errors: yes
+
+    - name: Display verification results
+      ansible.builtin.debug:
+        msg: 
+          - "sshpiper on port 22: {{ 'OK' if sshpiper_check.state == 'started' else 'FAILED' }}"
+          - "SSH on port 2222: {{ 'OK' if ssh_check.state == 'started' else 'FAILED' }}"
+
+handlers:
+  - name: Restart SSH
+    ansible.builtin.systemd:
+      name: sshd
+      state: restarted
+
+  - name: Restart sshpiper
+    ansible.builtin.systemd:
+      name: sshpiperd
+      state: restarted
+
+  - name: Restart Shorewall
+    ansible.builtin.systemd:
+      name: shorewall
+      state: restarted
+
+  - name: Reload systemd
+    ansible.builtin.systemd:
+      daemon_reload: yes


### PR DESCRIPTION
- Updated the Ansible role to configure sshpiper to run on port 22 and the SSH service on port 2222.
- Modified the SSH configuration to change the listening port.
- Adjusted the sshpiper configuration to listen on port 22.
- Updated Shorewall rules to allow traffic on both ports.
- Added service management tasks to ensure both sshpiper and SSH are enabled and started.